### PR TITLE
Currently fix WindowSystem event names; AudioFormatType from int to int

### DIFF
--- a/snow/platform/web/window/WindowSystem.hx
+++ b/snow/platform/web/window/WindowSystem.hx
@@ -113,7 +113,7 @@ import snow.window.WindowSystem;
                     lib.dispatch_system_event({
                         type : SystemEventType.window,
                         window : {
-                            type : WindowEventType.window_moved,
+                            type : WindowEventType.moved,
                             timestamp : lib.time,
                             window_id : _window.id,
                             event : { x:_rect.left, y:_rect.top }
@@ -124,7 +124,7 @@ import snow.window.WindowSystem;
                     lib.dispatch_system_event({
                         type : SystemEventType.window,
                         window : {
-                            type : WindowEventType.window_size_changed,
+                            type : WindowEventType.size_changed,
                             timestamp : lib.time,
                             window_id : _window.id,
                             event : { x:_rect.width, y:_rect.height }
@@ -472,7 +472,7 @@ import snow.window.WindowSystem;
             lib.dispatch_system_event({
                 type : SystemEventType.window,
                 window : {
-                    type : WindowEventType.window_leave,
+                    type : WindowEventType.leave,
                     timestamp : _mouse_event.timeStamp,
                     window_id : _window.id,
                     event : _mouse_event
@@ -489,7 +489,7 @@ import snow.window.WindowSystem;
             lib.dispatch_system_event({
                 type : SystemEventType.window,
                 window : {
-                    type : WindowEventType.window_enter,
+                    type : WindowEventType.enter,
                     timestamp : _mouse_event.timeStamp,
                     window_id : _window.id,
                     event : _mouse_event

--- a/snow/types/Types.hx
+++ b/snow/types/Types.hx
@@ -157,7 +157,7 @@ typedef ImageInfo = {
 } //ImageInfo
 
 /** The type of audio format */
-@:enum abstract AudioFormatType(Int) {
+@:enum abstract AudioFormatType(Int) from Int to Int {
 
     var unknown  = 0;
     var ogg      = 1;


### PR DESCRIPTION
This pull request solves following problems when targetting web:

```
snow/platform/web/assets/AssetSystem.hx:274: characters 23-30 : snow.types.AudioFormatType should be Int
snow/platform/web/window/WindowSystem.hx:475: characters 27-55 : snow.types.WindowEventType has no field window_leave
snow/platform/web/window/WindowSystem.hx:492: characters 27-55 : snow.types.WindowEventType has no field window_enter
snow/platform/web/window/WindowSystem.hx:116: characters 35-63 : snow.types.WindowEventType has no field window_moved
snow/platform/web/window/WindowSystem.hx:127: characters 35-70 : snow.types.WindowEventType has no field window_size_changed
```
