### PR TITLE
Implemented textinput event on web platform

### DIFF
--- a/snow/platform/web/input/InputSystem.hx
+++ b/snow/platform/web/input/InputSystem.hx
@@ -97,6 +97,51 @@ class InputSystem extends InputSystemBinding {
         // :unsupported: :todo:
     } //text_input_rect
 
+    function on_textinput( _key_event:js.html.KeyboardEvent ) {
+
+            var letter:String = "";
+
+            switch(_key_event.keyCode)
+            {
+                case 65: letter = "A";
+                case 66: letter = "B";
+                case 67: letter = "C";
+                case 68: letter = "D";
+                case 69: letter = "E";
+                case 70: letter = "F";
+                case 71: letter = "G";
+                case 72: letter = "H";
+                case 73: letter = "I";
+                case 74: letter = "J";
+                case 75: letter = "K";
+                case 76: letter = "L";
+                case 77: letter = "M";
+                case 78: letter = "N";
+                case 79: letter = "O";
+                case 80: letter = "P";
+                case 81: letter = "Q";
+                case 82: letter = "R";
+                case 83: letter = "S";
+                case 84: letter = "T";
+                case 85: letter = "U";
+                case 86: letter = "V";
+                case 87: letter = "W";
+                case 88: letter = "X";
+                case 89: letter = "Y";
+                case 90: letter = "Z";
+            }
+
+            //window id is 1 because keys come from the page, so always the main window
+        manager.dispatch_text_event(
+            letter,
+            0,
+            3,
+            TextEventType.input,
+            _key_event.timeStamp,
+            1
+        );
+        
+    } //on_textinput
 
     function on_mousedown( _mouse_event:js.html.MouseEvent ) {
 


### PR DESCRIPTION
This is a dummy implementation of the textinput event for the web platform.

It doesn't implement anything related to `text_input_start`, `text_input_stop` or `text_input_rect` but is still dispatching a text event.

It's probably not a solution for snow but makes luxe workable with text events for the web. There seems to have 3 types of text events: `unkown`, `edit` and `input`; My PR handles only the `input` type as i'm not sure if luxe even makes use of the `edit` type.

It's a workaround, but it works.

As a side note: I'm catching only one letter per frame, i'm not sure how it's implemented on the native side or if the event loop is independant of the rest of the world but it could be an issue for more UI-oriented apps with low framerates.