### PR TITLE
Fix snow.platform.web.utils.ByteArray resizing

### DIFF
--- a/snow/platform/web/utils/ByteArray.hx
+++ b/snow/platform/web/utils/ByteArray.hx
@@ -592,7 +592,7 @@ import snow.types.Types;
 
             if (allocated < value)
                 _snowResizeBuffer(allocated = Std.int(Math.max(value, allocated * 2)));
-            else if (allocated > value)
+            else if (allocated > value * 2)
                 _snowResizeBuffer(allocated = value);
             length = value;
             return value;


### PR DESCRIPTION
In my app ByteArray has very slow performance while reading big json file.
I dig into this problem, and found that set_length calls _snowResizeBuffer at every writeByte.
Illustration:

value | allocated | action
--- | --- | ---
- | 0 | initial
1 | 1 | up resize
2 | 2 | up resize
3 | 4 | up resize
4 | 4 | -
5 | 8 | up resize
6 | 6 | down resize
7 | 12 | up resize
8 | 8 | down resize
9 | 16 | up resize
10 | 10 | down resize
... | ... | ... etc ...

My proposal is to do down resize if allocated are twice more than required value. 