### PR TITLE
web; windowing; added parent_element

### DIFF
--- a/snow/core/web/window/Windowing.hx
+++ b/snow/core/web/window/Windowing.hx
@@ -44,7 +44,8 @@ class Windowing implements snow.modules.interfaces.Windowing {
             title:_config.title,
             width:_config.width,
             x:_config.x,
-            y:_config.y
+            y:_config.y,
+			parent_element:_config.parent_element,
         }
     }
 
@@ -63,8 +64,16 @@ class Windowing implements snow.modules.interfaces.Windowing {
             _handle.style.position = 'relative';
             _handle.style.background = '#000';
 
-                //add it to the document
-            js.Browser.document.body.appendChild(_handle);
+			//add it to the document
+			var element = null;
+			if(config.parent_element != null) {
+				element = js.Browser.document.getElementById(config.parent_element);
+			} 
+			if(element == null) {
+				js.Browser.document.body.appendChild(_handle);
+			} else {
+				element.appendChild(_handle);
+			}
 
             //:todo: These options need to be exposed and documented
         var _gl_context = _handle.getContextWebGL({ alpha:false, premultipliedAlpha:false, antialias: render_config.antialiasing > 0 });

--- a/snow/types/Types.hx
+++ b/snow/types/Types.hx
@@ -307,6 +307,8 @@ typedef WindowConfig = {
     @:optional var title        : String;
         /** disables input arriving at/from this window. default: false */
     @:optional var no_input     : Bool;
+		/** the id of the parent_element for web. Leave this alone to use the body element. */
+    @:optional var parent_element : String;
 
 } //WindowConfig
 


### PR DESCRIPTION
To be able to append the canvas to an element via id. It defaults to the `body` element if not.