### PR TITLE
Hide cursor within bounds of canvas only

### DIFF
--- a/snow/core/web/window/Windowing.hx
+++ b/snow/core/web/window/Windowing.hx
@@ -421,7 +421,7 @@ class Windowing implements snow.modules.interfaces.Windowing {
 
         if(cursor_style == null) {
             cursor_style = js.Browser.document.createStyleElement();
-            cursor_style.innerHTML = '* { cursor:none; }';
+            cursor_style.innerHTML = 'canvas { cursor:none; }';
         }
 
         if(enable && !_cursor_visible) {


### PR DESCRIPTION
Hides the system cursor only within the bounds of the canvas element instead of the entire browser window. Fixes underscorediscovery/luxe#319